### PR TITLE
Added a table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Overview
-Kinetic is a key-value storage system. A Kinetic Device (e.g. a Kinetic Drive or a traditional server running the Java Reference Implementation) stores key-value objects. Kinetic Client applications can communicate with a Kinetic Device by sending messages over a network using TCP. Each individual message is called a “Kinetic Protocol Data Unit” (Kinetic PDU) and represents an individual request or response. For example, a Kinetic Client may send a message requesting the value associated with a particular key to a Kinetic Device. The device would respond with a message containing the value.
+Kinetic is a key-value storage system. A Kinetic Device (e.g. a Kinetic Drive or a traditional server running the Java Reference Implementation) stores key-value objects. Kinetic Client applications can communicate with a Kinetic Device by sending messages over a network using TCP. Each individual message is called a “Kinetic Protocol Data Unit” (Kinetic PDU) and represents an individual request or response. For example, a Kinetic Client may send a message requesting the value associated with a particular key to a Kinetic Device. The device would respond with a message containing the value. 
 
 ## Document Assumptions
 This document describes the structure of Protocol Buffer messages in detail. It is important to have a familiarity with the Protocol Buffer data interchange format ([https://code.google.com/p/protobuf/](https://code.google.com/p/protobuf/)). Where data types are specified with respect to fields in `protobuf` messages, the Scalar Value Types documented here: [https://developers.google.com/protocol-buffers/docs/proto](https://developers.google.com/protocol-buffers/docs/proto) will be used.
@@ -44,9 +44,9 @@ This document describes the structure of Protocol Buffer messages in detail. It 
 _Table of Contents generated with [DocToc](http://doctoc.herokuapp.com/)_
 
 # Kinetic Protocol Data Unit Structure
-A Kinetic Protocol Data Unit is composed of a Protocol Buffer (`protobuf`) message, containing operation metadata & key-value metadata, and the value. It is important to note that the value is not encoded in the `protobuf` message; it is a separate top-level component of the Kinetic PDU.
+A Kinetic Protocol Data Unit is composed of a Protocol Buffer (`protobuf`) message, containing operation metadata & key-value metadata, and the value. It is important to note that the value is not encoded in the `protobuf` message; it is a separate top-level component of the Kinetic PDU. 
 
-Specifically, a Kinetic PDU is structured as follows:
+Specifically, a Kinetic PDU is structured as follows: 
 
 
 | Offset | Type | Length |  Description |
@@ -70,7 +70,7 @@ Each command contains a:
 - Body, containing operation-specific information, such as key-value information for PUT or key range information for GETKEYRANGE.
 - Status, containing information about whether an associated operation succeeded or failed (and why).
 
-The message structure for each operation will be described in depth in the following sections.
+The message structure for each operation will be described in depth in the following sections. 
 
 # Access Control
 The Kinetic Protocol supports restricting the operations a requester (identity) can perform by way of Access Control Lists (ACLs). They are structured as follows:
@@ -84,11 +84,11 @@ The Kinetic Protocol supports restricting the operations a requester (identity) 
 		// client and the device, used to sign requests.
 		optional bytes key = 2;
 
-		// This is the algorithm used for performing the HMAC for messages for
+		// This is the algorithm used for performing the HMAC for messages for 
 		// this identity.
 		// The supported values are: HmacSHA1.
 	    optional HMACAlgorithm hmacAlgorithm = 3;
-
+	
 		// Scope is the core of an ACL, an identity can have several.
 		// See below.
 		repeated Scope scope = 4;
@@ -98,18 +98,18 @@ The Kinetic Protocol supports restricting the operations a requester (identity) 
 		// those permissions apply to by using the offset, value,
 		// and TlsRequired fields
 		message Scope {
-			// Offset and value are optional and should be used to restrict
+			// Offset and value are optional and should be used to restrict 
 			// which keys the Scope applies to. If offset and value are
 			// specified, the permission will only apply to keys that match
 			// the value at the given offset. This is analogous to a substring
 			// match in many languages, where the key in question is the target.
 			optional int64 offset = 1;
 			optional bytes value = 2;
-
+			
 			// The Permission being granted.
 			// There can be many, there must be at least one.
 			repeated Permission permission = 3;
-
+			
 			// Optional boolean, defaults to false.
 			// When set to true, this scope only applies to SSL connections.
 			// Even if an identity has an ACL with a scope containing a specific
@@ -117,7 +117,7 @@ The Kinetic Protocol supports restricting the operations a requester (identity) 
 			// TlsRequired is true and the identity makes a non-ssl request,
 			// Kinetic will behave as if the identity does not have that
 			// permission.
-			optional bool TlsRequired = 4;
+			optional bool TlsRequired = 4; 
 		}
 
 		// These are the permissions that can be included in a scope
@@ -135,21 +135,21 @@ The Kinetic Protocol supports restricting the operations a requester (identity) 
 
 		// Currently only one valid HMAC algorithm is supported
 		enum HMACAlgorithm {
-           // Added to allow additional HmacAlgorithms without breaking
+           // Added to allow additional HmacAlgorithms without breaking 
            // backward compatibility.
-           Unknown = 0;
+           Unknown = 0; 
            // this is the default
-           HmacSHA1 = 1;
+           HmacSHA1 = 1; 
         }
 
 	}
 
 ```
 
-See the Security section below for details on setting ACLs.
+See the Security section below for details on setting ACLs. 
 
 ## Examples
-In this section we'll give some concrete examples of how ACLs can be used.
+In this section we'll give some concrete examples of how ACLs can be used. 
 
 ###Client 1
 
@@ -160,7 +160,7 @@ ACL {
 	identity: 1
 	key: "a3b38c37298f7f01a377518dae81dd99655b2be8129c3b2c6357b7e779064159"
 	HMACAlgorithm: HmacSHA1
-
+	
 	// There can be multiple scopes, we'll show that in these examples by
 	// repeated scope objects like this
 	scope {
@@ -185,8 +185,8 @@ Suppose client 2 has an ACL like so:
 ACL {
 	identity: 2
 	key: "13010b8d8acdbe6abc005840aad1dc5dedb4345e681ed4e3c4645d891241d6b2"
-	HMACAlgorithm: HmacSHA1
-
+	HMACAlgorithm: HmacSHA1	
+	
 	scope {
 		permission: SECURITY
 		TlsRequired: true
@@ -198,7 +198,7 @@ Client 2 would be able to create new identities and set ACLs (using the Security
 
 
 
-
+	
 
 # Operation Details
 
@@ -214,8 +214,8 @@ There are many fields in the `protobuf` message which can be specified on many o
 command {
   header {
   	// Optional int64, default value is 0
-    // The version number of this cluster definition. If this is not equal to
-    // the value on the device, the request is rejected and will return a
+    // The version number of this cluster definition. If this is not equal to 
+    // the value on the device, the request is rejected and will return a 
     // `VERSION_FAILURE` `statusCode` in the `Status` message.
     clusterVersion: ...
 
@@ -226,21 +226,21 @@ command {
     identity: ...
 
 	// Required int64
-    // A unique number for this connection between the source and target.
-    // On the first request to the drive, this should be the time of day in
+    // A unique number for this connection between the source and target. 
+    // On the first request to the drive, this should be the time of day in 
     // seconds since 1970. The drive can change this number and the client must
-    // continue to use the new number and the number must remain constant
+    // continue to use the new number and the number must remain constant 
     // during the session
     connectionID: ...
 
 	// Required int64
-	// Sequence is a monotonically increasing number for each request in a TCP
-	// connection.
+	// Sequence is a monotonically increasing number for each request in a TCP 
+	// connection. 
     sequence: ...
 
 	// Required MessageType
     // The message type identifies which sort of operation this is.
-    // See the MessageType enum in the protobuf definition for all potential
+    // See the MessageType enum in the protobuf definition for all potential 
     // values.
     // Note that the *_RESPONSE message types are reserved for messages from
     // the Kinetic Device to the client (i.e. responses).
@@ -252,12 +252,12 @@ command {
 }
 
 // Required bytes
-// The HMAC of this message used to verify integrity.
-// The HMAC is taken of the byte-representaiton of the command message of this
+// The HMAC of this message used to verify integrity. 
+// The HMAC is taken of the byte-representaiton of the command message of this 
 // protobuf message. An identity-specific shared secret is used to compute the HMAC.
 // The Kinetic Device must have the key associated with the identity in
 // the header.
-// For example, in pseudocode where a computeHMAC function exists which takes
+// For example, in pseudocode where a computeHMAC function exists which takes 
 // a value and an algorithm:
 //	 hmac = computeHMAC(message.command.toBytes(), identityHMACAlgorithm)
 hmac: "..."
@@ -269,15 +269,15 @@ hmac: "..."
 command {
   header {
   	// Required int64.
-    // In a response message, ackSequence will be the same as the
+    // In a response message, ackSequence will be the same as the 
     // sequence value set in the request message.
     // The client can use this to map async responses to their
-    // associated requests.
+    // associated requests. 
     // This is important because operations within a connection may be reorderd.
     ackSequence: ...
-
+    
     // In a response, messageType corresponds to the requested messageType.
-    // For instance, requests with a PUT messageType will receive a response
+    // For instance, requests with a PUT messageType will receive a response 
     // with a PUT_REPONSE messageType.
     messageType: ...
   }
@@ -285,15 +285,15 @@ command {
 	// Omitted in this cross-cutting documentation section
   }
   status {
-    // Every response from the Kinetic Device will specify a code indicating
-    // whether the request was successful, or the specific error case
-    // encountered. The full list of codes is specified by the
+    // Every response from the Kinetic Device will specify a code indicating 
+    // whether the request was successful, or the specific error case 
+    // encountered. The full list of codes is specified by the 
     // Status.StatusCode enum.
     code: SUCCESS
   }
 }
 // Required bytes
-// See the description for the request above. Responses will include an HMAC
+// See the description for the request above. Responses will include an HMAC 
 // in addition to request, using the identity-specific key.
 hmac: ""
 
@@ -302,11 +302,11 @@ hmac: ""
 ###Error Cases###
 When an error occurs on the Kinetic Device, the response message includes a `status` with a `code`. These codes are enumerated in the `StatusCode` enum in the protocol definition. They will be discussed here in more detail.
 
-* `INTERNAL_ERROR` indicates that the Kinetic Device experiences a malfunction. (Currently this code is returned in certain cases that don't indicate a drive malfunction, these will be updated.)
+* `INTERNAL_ERROR` indicates that the Kinetic Device experiences a malfunction. (Currently this code is returned in certain cases that don't indicate a drive malfunction, these will be updated.) 
 * `HMAC_FAILURE` indicates that the HMAC of the request is incorrect or missing. This will also be returned when an unknown identity is set in the header, since the device cannot verify an HMAC for an unknown identity.
 * `NOT_AUTHORIZED` indicates the attemped operation could not be completed because the identity set in the header did not have authorization. This may mean that the identity does not have the required Permission in any Scope in the ACL, or it may indicate that the Scope containing that Permission does not apply (due to offset & index or tls rules).
 * `VERSION_FAILURE` indicates that the `clusterVersion` of the Kinetic Device does not match the `clusterVersion` set in the header of the requesting message.
-* `NOT_FOUND` indicates that the requested key was not found in the Kinetic Device's data store.
+* `NOT_FOUND` indicates that the requested key was not found in the Kinetic Device's data store. 
 * `VERSION_MISMATCH` indicates that the `PUT` or `DELETE` operation failed because the `dbVersion` passed in the `KeyValue` object does not match the store's version. Pasing `force: true` in the `KeyValue` object ignores the mismatch and completes the operation.
 * `NO_SPACE` indicates that the drive is full. There are background processes which may free space, so this error may occur once, and not on subsequent tries even though no data has been explicitly removed. Similarly, executing a delete may not immediately free space, so a `PUT` which fails with this error may not immediately succeed even after a `DELETE` which should free space.
 * `NO_SUCH_HMAC_ALGORITHM` indicates that the `hmacAlgorithm` field in the `Security` message was invalid.
@@ -358,7 +358,7 @@ command {
   header {
     // See above
     ackSequence: ...
-
+    
     // messageType should be NOOP_RESPONSE
     messageType: NOOP_RESPONSE
   }
@@ -387,13 +387,13 @@ command: {
 
 			// Required bytes
 	      	// Versions are set on objects to support optimistic locking.
-      		// For operations that modify data, if the dbVersion sent in the
+      		// For operations that modify data, if the dbVersion sent in the 
       		// request message does not match the version stored in the db, the
       		// request will fail.
 	      	dbVersion: "..."
 
 			// Required bytes
-      		// Specifies what the next version of the data will be if this
+      		// Specifies what the next version of the data will be if this 
       		// operation is successful.
 	      	newVersion: "..."
 
@@ -404,9 +404,9 @@ command: {
 
 			// Optional bytes
 	      	// The integrity value for the data. This value should be computed
-      		// by the client application by applying the hash algorithm
-      		// specified below to the value (and only to the value).
-      		// The algorithm used should be specified in the algorithm field.
+      		// by the client application by applying the hash algorithm 
+      		// specified below to the value (and only to the value). 
+      		// The algorithm used should be specified in the algorithm field. 
       		// The Kinetic Device will not do any processing on this value.
       		tag: "..."
 
@@ -415,15 +415,15 @@ command: {
       		algorithm: ...
 
 		// Optional Synchronization enum value, defaults to WRITETHROUGH
-      		// Allows client to specify if the data must be written to disk
+      		// Allows client to specify if the data must be written to disk 
       		// immediately, or can be written in the future.
       		//
       		// WRITETHROUGH:  This request is made persistent before returning.
       		//                This does not effect any other pending operations.
       		// WRITEBACK:     They can be made persistent when the drive chooses,
       		//        	  or when a subsequent FLUSH is give to the drive.
-      		// FLUSH: 	  All pending information that has not been written is
-      		//		  pushed to the disk and the command that specifies
+      		// FLUSH: 	  All pending information that has not been written is 
+      		//		  pushed to the disk and the command that specifies 
       		// 		  FLUSH is written last and then returned. All WRITEBACK writes
       		//		  that have received ending status will be guaranteed to be
       		//		  written before the FLUSH operation is returned completed.
@@ -539,7 +539,7 @@ command {
   // See top level cross cutting concerns for header details
   header {
     ackSequence: ...
-
+    
     // messageType should be DELETE_RESPONSE
     messageType: DELETE_RESPONSE
   }
@@ -635,13 +635,13 @@ keyValue {
       // Optional bool, defaults to false.
       // If true, only metadata (not the full value) will be returned
       // If false, metadata and value will be returned
-	  metadataOnly: ...
+	  metadataOnly: ...    
 }
 ```
 
 
 ### GET
-The `GET` operation is used to retrieve the value and metadata for a given key.
+The `GET` operation is used to retrieve the value and metadata for a given key. 
 
 **Request Message**
 
@@ -653,7 +653,7 @@ command {
     identity: ...
     connectionID: ...
     sequence: ...
-
+    
     // The mesageType should be GET
     messageType: GET
   }
@@ -672,7 +672,7 @@ hmac: "..."
 
 A successful response will return the value in the top level Kinetic PDU, and will have a `SUCCESS` status:
 
- ```
+ ```   
 command {
   header {
   	// See above
@@ -776,8 +776,8 @@ command {
   }
   body {
     keyValue {
-      // A key is required. Note that this is different from GET in that you
-      // will not get the value for this key, but the value for the subsequent
+      // A key is required. Note that this is different from GET in that you 
+      // will not get the value for this key, but the value for the subsequent 
       // key in the ordering.
       key: "..."
     }
@@ -802,7 +802,7 @@ command {
       // This is the key for the value that is being returned
       // This will be different from the key passed in the request
       key: "..."
-
+      
       // These fields are documented above
       dbVersion: "..."
       tag: "..."
@@ -810,7 +810,7 @@ command {
     }
   }
   status {
-	// If the operation does not succeed, a different code will be specified.
+	// If the operation does not succeed, a different code will be specified. 
 	// See below.
     code: SUCCESS
   }
@@ -822,10 +822,10 @@ hmac: "..."
 Error Cases:
 
 * `code = NOT_FOUND`
-	* There is no key in the store that is sorted after the given key.
+	* There is no key in the store that is sorted after the given key. 
 	* This can occur if the given key is the last key in the store, of if the key given is not included in the store but would be sorted after the last key.
 * `code = NOT_AUTHORIZED` The identity does not have read permission on the key that would be returned.
-
+	
 Edge Cases:
 
  * If a `key` is provided which is not found in the store, the service will find the first key which would be sorted after the given key. For example, if the store has keys `key0` and `key2` and the client sends a request for `GETNEXT` of `key1`, the device will return the value for `key2`.
@@ -849,10 +849,10 @@ command {
   }
   body {
     keyValue {
-      // A key is required. Note that this is different from GET in that you
+      // A key is required. Note that this is different from GET in that you 
       // will not get the value for this key, but the value for the subsequent
       // key in the ordering.
-
+      
       key: "..."
     }
   }
@@ -876,7 +876,7 @@ command {
       // This is the key for the value that is being returned
       // This will be different from the key passed in the request
       key: "..."
-
+      
       // These fields are documented above
       dbVersion: "..."
       tag: "..."
@@ -884,7 +884,7 @@ command {
     }
   }
   status {
-	// If the operation does not succeed, a different code will be specified.
+	// If the operation does not succeed, a different code will be specified. 
 	// See below.
     code: SUCCESS
   }
@@ -896,11 +896,11 @@ hmac: "..."
 Error Cases:
 
 * `code = NOT_FOUND`
-	* There is no key in the store that is sorted brefore the given key.
+	* There is no key in the store that is sorted brefore the given key. 
 	* This can occur if the given key is the first key in the store, of if the key given is not included in the store but would be sorted before the first key.
 * `code = NOT_AUTHORIZED`:
 	* If the identity does not have read permission on the key that would be returned.
-
+	
 Edge Cases:
 
  * If a `key` is provided which is not found in the store, the service will find the first key which would be sorted before the given key. For example, if the store has keys `key0` and `key2` and the client sends a request for `GETPREVIOUS` of `key1`, the device will return the value for `key0`.
@@ -923,7 +923,7 @@ command {
     identity: ...
     connectionID: ...
     sequence: ...
-
+    
     // messageType should be GETKEYRANGE
     messageType: GETKEYRANGE
   }
@@ -932,24 +932,24 @@ command {
     range {
       // Required bytes, the beginning of the requested range
       startKey: "..."
-
+      
       // Optional bool, defaults to false
-      // True indicates that the start key should be included in the returned
+      // True indicates that the start key should be included in the returned 
       // range
       startKeyInclusive: ...
-
+      
       // Required bytes, the end of the requested range
       endKey: "..."
 
       // Optional bool, defaults to false
-      // True indicates that the end key should be included in the returned
+      // True indicates that the end key should be included in the returned 
       // range
       endKeyInclusive: ...
-
+      
       // Required int32, must be greater than 0
       // The maximum number of keys returned, in sorted order
       maxReturned: ...
-
+      
       // Optional bool, defaults to false
       // If true, the key range will be returned in reverse order, starting at
       // endKey and moving back to startKey.  For instance
@@ -972,8 +972,8 @@ command {
     messageType: GETKEYRANGE_RESPONSE
   }
   body {
-  	// The range message is populated with up to maxReturned keys.
-  	// If no keys are found in the range then the range message will be omitted
+  	// The range message is populated with up to maxReturned keys. 
+  	// If no keys are found in the range then the range message will be omitted 
   	// and the status code will be SUCCESS
     range {
       key: "..."
@@ -1013,25 +1013,25 @@ The `SETUP` operation can be used to set the device's `clusterVersion` and `pin`
 
 **Request Message**
 
-```
+``` 
 command {
   header {
     // Important: this should be the current cluster version. This operation is
-    // intended to change the clusterVersion, but the current clusterVersion
+    // intended to change the clusterVersion, but the current clusterVersion 
     // must be specified here.
     clusterVersion: ...
-
+    
 	// See top level cross cutting concerns for header details
     identity: ...
     connectionID: ...
     sequence: ...
-
+    
 	// The messageType should be SETUP
     messageType: SETUP
   }
   body {
     setup {
-      // Required int64, needed to update the cluster version
+      // Required int64, needed to update the cluster version 
       // (otherwise request will be treated as a different Setup operation)
       // This is the clusterVersion being set on the device.
       newClusterVersion: 1
@@ -1077,7 +1077,7 @@ command {
   }
   body {
     setup {
-      // Required bool, defaults to false if omitted.
+      // Required bool, defaults to false if omitted. 
       // Must be true for this request to be treated as an ISE.
       instantSecureErase: true
     }
@@ -1121,7 +1121,7 @@ command {
   }
   body {
     setup {
-      // Required bool, must be present and true to indicate that this is
+      // Required bool, must be present and true to indicate that this is 
       // a firmware download operation.
       // Indicates that the value (in the Kinetic PDU) will contain the firmware
       firmwareDownload: true
@@ -1172,14 +1172,14 @@ command {
     identity: ...
     connectionID: ...
     sequence: ...
-
+    
     // messageType should be SECURITY
     messageType: SECURITY
   }
   body {
-    // The security message must be present and contain at least one acl
+    // The security message must be present and contain at least one acl 
     // message. Multiple are allowed but only one can be specified per identity.
-    // Note that security message overwrites the stored ACL list entirely,
+    // Note that security message overwrites the stored ACL list entirely, 
     // no updating is supported.
     security {
       acl {
@@ -1187,10 +1187,10 @@ command {
         identity: 1
         // Required bytes, the identity's HMAC key, a shared secret
         key: "...."
-        // Required HMACAlgorithm, the algorithm used to compute the HMAC for
+        // Required HMACAlgorithm, the algorithm used to compute the HMAC for 
         // this identity
         hmacAlgorithm: ...
-
+        
         // The scope message has at least one permission, in this example there
         // are many
         scope {
@@ -1204,7 +1204,7 @@ command {
           permission: SECURITY
         }
       }
-
+      
       // This ACL shows that multiple scopes can be set for a identity in one
       // ACL message
       acl {
@@ -1216,9 +1216,9 @@ command {
         scope {
           permission: READ
         }
-
+        
         // This scope gives identity 2 the ability to write keys if and only if
-        // "test" is a substring of key starting at offset 3. For example, with
+        // "test" is a substring of key starting at offset 3. For example, with 
         // this scope identity 2 could PUT keys: "xyztest1", "001test2", etc
         // but could not put keys: "somethingElse", "test123", "1234test"
         scope {
@@ -1227,7 +1227,7 @@ command {
           permission: WRITE
         }
       }
-
+      
       // More ACLs for additional identities may be specified in the
       // same security message...
       acl {
@@ -1259,7 +1259,7 @@ hmac: "..."
 command {
   header {
     ackSequence: ...
-
+    
     // messageType should be SECURITY_RESPONSE
     messageType: SECURITY_RESPONSE
   }
@@ -1310,7 +1310,7 @@ command {
   }
   body {
     // The body should contain a getLog message, which must have
-    // at least one value for type. Multiple are allowed.
+    // at least one value for type. Multiple are allowed. 
     // Here all types are requested.
     getLog {
       type: CAPACITIES
@@ -1344,23 +1344,23 @@ command {
       type: TEMPERATURES
       type: UTILIZATIONS
       type: LIMITS
-
+      
       // Many utilization messages may be returned
       utilization {
-      	// Required string, the name of the rescource being reported
+      	// Required string, the name of the rescource being reported       
       	// For example: HDA, ENO, CPU...
         name: "..."
         // Required float, the value for this resource's utilization.
         // value will be between 0.00 and 1.00.
         value: 0.2
       }
-
+      
       utilization {
         name: "...""
         value: ...
       }
       ...
-
+      
       // Many temperature messages may be returned
       temperature {
       	// Required string, the name of the resource being reported
@@ -1372,13 +1372,13 @@ command {
         minimum: 5.0
         // Required float, the current temperature in degrees celcius
         maximum: 100.0
-		// Required float, the current temperature in degrees celcius
+		// Required float, the current temperature in degrees celcius        
         target: 25.0
       }
-
-	  // Only one configuration message will be included
+	
+	  // Only one configuration message will be included      
       configuration {
-        // string, the vendor of the Kinetic Device.
+        // string, the vendor of the Kinetic Device. 
         vendor: "..."
 
         // string, the model of the Kinetic Device
@@ -1412,7 +1412,7 @@ command {
         // string, a checksum of the source code
         sourceHash: "..."
       }
-
+      
       // There should be one statistics message per messageType (GET, PUT, etc)
       // The statistics messages aggregate statistics for each messageType.
       statistics {
@@ -1420,7 +1420,7 @@ command {
         messageType: PUT
         // Required sint64, how many times this messageType has been received
         count: ...
-        // Required sint64, the sum length of all the value portion of the
+        // Required sint64, the sum length of all the value portion of the 
         // Kinetic PDU messages sent since starting the Kinetic Device
         bytes: ...
       }
@@ -1430,7 +1430,7 @@ command {
         count: ...
         bytes: ...
       }
-
+      
       // Only one capacity message will be included
       capacity {
         // uint64
@@ -1438,10 +1438,10 @@ command {
       	// float
       	portionFull: ...
       }
-
+      
       // bytes representing recent Kinetic Device log messages
       messages: "..."
-
+      
       // limits that the device will enforce
       limits {
         maxKeySize = ...
@@ -1464,7 +1464,7 @@ command {
 
 
 ## Peer to Peer
-The `PEER2PEERPUSH` operation allows a client to instruct a Kinetic Device to copy a set of keys (and associated value and metadata) to another Kinetic Device. Peer To Peer operations can be nested, so a client could tell device A to copy certain keys to device B, and then have device B copy a set of keys to device C, and so on.
+The `PEER2PEERPUSH` operation allows a client to instruct a Kinetic Device to copy a set of keys (and associated value and metadata) to another Kinetic Device. Peer To Peer operations can be nested, so a client could tell device A to copy certain keys to device B, and then have device B copy a set of keys to device C, and so on. 
 
 
 **Request Message**
@@ -1485,7 +1485,7 @@ command {
         hostname: "..."
         // Required int32, the port on which the peer is running the Kinetic service
         port: ...
-        // Optional boolean, defaults to false.
+        // Optional boolean, defaults to false. 
         // Currently SSL is not supported so this must be false.
         tls: ...
       }
@@ -1493,16 +1493,16 @@ command {
       	// Required bytes, the key to copy from the source peer.
         key: ""
 
-		// Optional bytes, the
+		// Optional bytes, the 
 		version: "..."
-
+		
 		// Optional bool, defaults to false
 		// If true, force write ignoring version
 		force: ...
-
+		
   		// Optional bytes, the key to use in the destination peer.
 		newKey: "..."
-
+		
 		// This is a nested Peer To Peer Push operation. The recursive structure
 		// allows arbitrarily deep (up to the message size cap) nesting of
 		// p2p operations.
@@ -1560,10 +1560,10 @@ command {
           operation {
             key: "..."
 			status {
-				// Status messages can be nested. This is what it would be
+				// Status messages can be nested. This is what it would be 
 				// returned if an operation failed because the key was not found
          	 	code: NOT_FOUND
-	     	}
+	     	}           
           }
           operation: {
           	key: "...",

--- a/README.md
+++ b/README.md
@@ -1,13 +1,52 @@
 # Overview
-Kinetic is a key-value storage system. A Kinetic Device (e.g. a Kinetic Drive or a traditional server running the Java Reference Implementation) stores key-value objects. Kinetic Client applications can communicate with a Kinetic Device by sending messages over a network using TCP. Each individual message is called a “Kinetic Protocol Data Unit” (Kinetic PDU) and represents an individual request or response. For example, a Kinetic Client may send a message requesting the value associated with a particular key to a Kinetic Device. The device would respond with a message containing the value. 
+Kinetic is a key-value storage system. A Kinetic Device (e.g. a Kinetic Drive or a traditional server running the Java Reference Implementation) stores key-value objects. Kinetic Client applications can communicate with a Kinetic Device by sending messages over a network using TCP. Each individual message is called a “Kinetic Protocol Data Unit” (Kinetic PDU) and represents an individual request or response. For example, a Kinetic Client may send a message requesting the value associated with a particular key to a Kinetic Device. The device would respond with a message containing the value.
 
 ## Document Assumptions
 This document describes the structure of Protocol Buffer messages in detail. It is important to have a familiarity with the Protocol Buffer data interchange format ([https://code.google.com/p/protobuf/](https://code.google.com/p/protobuf/)). Where data types are specified with respect to fields in `protobuf` messages, the Scalar Value Types documented here: [https://developers.google.com/protocol-buffers/docs/proto](https://developers.google.com/protocol-buffers/docs/proto) will be used.
 
-# Kinetic Protocol Data Unit Structure
-A Kinetic Protocol Data Unit is composed of a Protocol Buffer (`protobuf`) message, containing operation metadata & key-value metadata, and the value. It is important to note that the value is not encoded in the `protobuf` message; it is a separate top-level component of the Kinetic PDU. 
+## Table of Contents
 
-Specifically, a Kinetic PDU is structured as follows: 
+- [Overview](#user-content-overview)
+    - [Document Assumptions](#user-content-document-assumptions)
+- [Kinetic Protocol Data Unit Structure](#user-content-kinetic-protocol-data-unit-structure)
+        - [Protobuf Structure](#user-content-protobuf-structure)
+- [Access Control](#user-content-access-control)
+    - [Examples](#user-content-examples)
+        - [Client 1](#user-content-client-1)
+        - [Client 2](#user-content-client-2)
+- [Operation Details](#user-content-operation-details)
+    - [Overview](#user-content-overview-1)
+    - [Cross-Cutting Concerns](#user-content-cross-cutting-concerns)
+        - [Error Cases](#user-content-error-cases)
+    - [No Op](#user-content-no-op)
+    - [Modify Value Operations](#user-content-modify-value-operations)
+        - [Cross-Cutting Concerns](#user-content-cross-cutting-concerns-1)
+        - [PUT](#user-content-put)
+        - [Delete](#user-content-delete)
+        - [Flush](#user-content-flush)
+    - [Read Operations](#user-content-read-operations)
+        - [Cross-Cutting Concenrs](#user-content-cross-cutting-concenrs)
+        - [GET](#user-content-get)
+        - [Get Version](#user-content-get-version)
+        - [Get Next](#user-content-get-next)
+        - [Get Previous](#user-content-get-previous)
+        - [Get Key Range](#user-content-get-key-range)
+    - [Setup](#user-content-setup)
+        - [Set Cluster Version](#user-content-set-cluster-version)
+        - [Set Pin](#user-content-set-pin)
+        - [Instant Secure Erase](#user-content-instant-secure-erase)
+        - [Firmware Download](#user-content-firmware-download)
+    - [Administration](#user-content-administration)
+        - [Security](#user-content-security)
+        - [Get Log](#user-content-get-log)
+    - [Peer to Peer](#user-content-peer-to-peer)
+
+_Table of Contents generated with [DocToc](http://doctoc.herokuapp.com/)_
+
+# Kinetic Protocol Data Unit Structure
+A Kinetic Protocol Data Unit is composed of a Protocol Buffer (`protobuf`) message, containing operation metadata & key-value metadata, and the value. It is important to note that the value is not encoded in the `protobuf` message; it is a separate top-level component of the Kinetic PDU.
+
+Specifically, a Kinetic PDU is structured as follows:
 
 
 | Offset | Type | Length |  Description |
@@ -31,7 +70,7 @@ Each command contains a:
 - Body, containing operation-specific information, such as key-value information for PUT or key range information for GETKEYRANGE.
 - Status, containing information about whether an associated operation succeeded or failed (and why).
 
-The message structure for each operation will be described in depth in the following sections. 
+The message structure for each operation will be described in depth in the following sections.
 
 # Access Control
 The Kinetic Protocol supports restricting the operations a requester (identity) can perform by way of Access Control Lists (ACLs). They are structured as follows:
@@ -45,11 +84,11 @@ The Kinetic Protocol supports restricting the operations a requester (identity) 
 		// client and the device, used to sign requests.
 		optional bytes key = 2;
 
-		// This is the algorithm used for performing the HMAC for messages for 
+		// This is the algorithm used for performing the HMAC for messages for
 		// this identity.
 		// The supported values are: HmacSHA1.
 	    optional HMACAlgorithm hmacAlgorithm = 3;
-	
+
 		// Scope is the core of an ACL, an identity can have several.
 		// See below.
 		repeated Scope scope = 4;
@@ -59,18 +98,18 @@ The Kinetic Protocol supports restricting the operations a requester (identity) 
 		// those permissions apply to by using the offset, value,
 		// and TlsRequired fields
 		message Scope {
-			// Offset and value are optional and should be used to restrict 
+			// Offset and value are optional and should be used to restrict
 			// which keys the Scope applies to. If offset and value are
 			// specified, the permission will only apply to keys that match
 			// the value at the given offset. This is analogous to a substring
 			// match in many languages, where the key in question is the target.
 			optional int64 offset = 1;
 			optional bytes value = 2;
-			
+
 			// The Permission being granted.
 			// There can be many, there must be at least one.
 			repeated Permission permission = 3;
-			
+
 			// Optional boolean, defaults to false.
 			// When set to true, this scope only applies to SSL connections.
 			// Even if an identity has an ACL with a scope containing a specific
@@ -78,7 +117,7 @@ The Kinetic Protocol supports restricting the operations a requester (identity) 
 			// TlsRequired is true and the identity makes a non-ssl request,
 			// Kinetic will behave as if the identity does not have that
 			// permission.
-			optional bool TlsRequired = 4; 
+			optional bool TlsRequired = 4;
 		}
 
 		// These are the permissions that can be included in a scope
@@ -96,21 +135,21 @@ The Kinetic Protocol supports restricting the operations a requester (identity) 
 
 		// Currently only one valid HMAC algorithm is supported
 		enum HMACAlgorithm {
-           // Added to allow additional HmacAlgorithms without breaking 
+           // Added to allow additional HmacAlgorithms without breaking
            // backward compatibility.
-           Unknown = 0; 
+           Unknown = 0;
            // this is the default
-           HmacSHA1 = 1; 
+           HmacSHA1 = 1;
         }
 
 	}
 
 ```
 
-See the Security section below for details on setting ACLs. 
+See the Security section below for details on setting ACLs.
 
 ## Examples
-In this section we'll give some concrete examples of how ACLs can be used. 
+In this section we'll give some concrete examples of how ACLs can be used.
 
 ###Client 1
 
@@ -121,7 +160,7 @@ ACL {
 	identity: 1
 	key: "a3b38c37298f7f01a377518dae81dd99655b2be8129c3b2c6357b7e779064159"
 	HMACAlgorithm: HmacSHA1
-	
+
 	// There can be multiple scopes, we'll show that in these examples by
 	// repeated scope objects like this
 	scope {
@@ -146,8 +185,8 @@ Suppose client 2 has an ACL like so:
 ACL {
 	identity: 2
 	key: "13010b8d8acdbe6abc005840aad1dc5dedb4345e681ed4e3c4645d891241d6b2"
-	HMACAlgorithm: HmacSHA1	
-	
+	HMACAlgorithm: HmacSHA1
+
 	scope {
 		permission: SECURITY
 		TlsRequired: true
@@ -159,7 +198,7 @@ Client 2 would be able to create new identities and set ACLs (using the Security
 
 
 
-	
+
 
 # Operation Details
 
@@ -175,8 +214,8 @@ There are many fields in the `protobuf` message which can be specified on many o
 command {
   header {
   	// Optional int64, default value is 0
-    // The version number of this cluster definition. If this is not equal to 
-    // the value on the device, the request is rejected and will return a 
+    // The version number of this cluster definition. If this is not equal to
+    // the value on the device, the request is rejected and will return a
     // `VERSION_FAILURE` `statusCode` in the `Status` message.
     clusterVersion: ...
 
@@ -187,21 +226,21 @@ command {
     identity: ...
 
 	// Required int64
-    // A unique number for this connection between the source and target. 
-    // On the first request to the drive, this should be the time of day in 
+    // A unique number for this connection between the source and target.
+    // On the first request to the drive, this should be the time of day in
     // seconds since 1970. The drive can change this number and the client must
-    // continue to use the new number and the number must remain constant 
+    // continue to use the new number and the number must remain constant
     // during the session
     connectionID: ...
 
 	// Required int64
-	// Sequence is a monotonically increasing number for each request in a TCP 
-	// connection. 
+	// Sequence is a monotonically increasing number for each request in a TCP
+	// connection.
     sequence: ...
 
 	// Required MessageType
     // The message type identifies which sort of operation this is.
-    // See the MessageType enum in the protobuf definition for all potential 
+    // See the MessageType enum in the protobuf definition for all potential
     // values.
     // Note that the *_RESPONSE message types are reserved for messages from
     // the Kinetic Device to the client (i.e. responses).
@@ -213,12 +252,12 @@ command {
 }
 
 // Required bytes
-// The HMAC of this message used to verify integrity. 
-// The HMAC is taken of the byte-representaiton of the command message of this 
+// The HMAC of this message used to verify integrity.
+// The HMAC is taken of the byte-representaiton of the command message of this
 // protobuf message. An identity-specific shared secret is used to compute the HMAC.
 // The Kinetic Device must have the key associated with the identity in
 // the header.
-// For example, in pseudocode where a computeHMAC function exists which takes 
+// For example, in pseudocode where a computeHMAC function exists which takes
 // a value and an algorithm:
 //	 hmac = computeHMAC(message.command.toBytes(), identityHMACAlgorithm)
 hmac: "..."
@@ -230,15 +269,15 @@ hmac: "..."
 command {
   header {
   	// Required int64.
-    // In a response message, ackSequence will be the same as the 
+    // In a response message, ackSequence will be the same as the
     // sequence value set in the request message.
     // The client can use this to map async responses to their
-    // associated requests. 
+    // associated requests.
     // This is important because operations within a connection may be reorderd.
     ackSequence: ...
-    
+
     // In a response, messageType corresponds to the requested messageType.
-    // For instance, requests with a PUT messageType will receive a response 
+    // For instance, requests with a PUT messageType will receive a response
     // with a PUT_REPONSE messageType.
     messageType: ...
   }
@@ -246,15 +285,15 @@ command {
 	// Omitted in this cross-cutting documentation section
   }
   status {
-    // Every response from the Kinetic Device will specify a code indicating 
-    // whether the request was successful, or the specific error case 
-    // encountered. The full list of codes is specified by the 
+    // Every response from the Kinetic Device will specify a code indicating
+    // whether the request was successful, or the specific error case
+    // encountered. The full list of codes is specified by the
     // Status.StatusCode enum.
     code: SUCCESS
   }
 }
 // Required bytes
-// See the description for the request above. Responses will include an HMAC 
+// See the description for the request above. Responses will include an HMAC
 // in addition to request, using the identity-specific key.
 hmac: ""
 
@@ -263,11 +302,11 @@ hmac: ""
 ###Error Cases###
 When an error occurs on the Kinetic Device, the response message includes a `status` with a `code`. These codes are enumerated in the `StatusCode` enum in the protocol definition. They will be discussed here in more detail.
 
-* `INTERNAL_ERROR` indicates that the Kinetic Device experiences a malfunction. (Currently this code is returned in certain cases that don't indicate a drive malfunction, these will be updated.) 
+* `INTERNAL_ERROR` indicates that the Kinetic Device experiences a malfunction. (Currently this code is returned in certain cases that don't indicate a drive malfunction, these will be updated.)
 * `HMAC_FAILURE` indicates that the HMAC of the request is incorrect or missing. This will also be returned when an unknown identity is set in the header, since the device cannot verify an HMAC for an unknown identity.
 * `NOT_AUTHORIZED` indicates the attemped operation could not be completed because the identity set in the header did not have authorization. This may mean that the identity does not have the required Permission in any Scope in the ACL, or it may indicate that the Scope containing that Permission does not apply (due to offset & index or tls rules).
 * `VERSION_FAILURE` indicates that the `clusterVersion` of the Kinetic Device does not match the `clusterVersion` set in the header of the requesting message.
-* `NOT_FOUND` indicates that the requested key was not found in the Kinetic Device's data store. 
+* `NOT_FOUND` indicates that the requested key was not found in the Kinetic Device's data store.
 * `VERSION_MISMATCH` indicates that the `PUT` or `DELETE` operation failed because the `dbVersion` passed in the `KeyValue` object does not match the store's version. Pasing `force: true` in the `KeyValue` object ignores the mismatch and completes the operation.
 * `NO_SPACE` indicates that the drive is full. There are background processes which may free space, so this error may occur once, and not on subsequent tries even though no data has been explicitly removed. Similarly, executing a delete may not immediately free space, so a `PUT` which fails with this error may not immediately succeed even after a `DELETE` which should free space.
 * `NO_SUCH_HMAC_ALGORITHM` indicates that the `hmacAlgorithm` field in the `Security` message was invalid.
@@ -319,7 +358,7 @@ command {
   header {
     // See above
     ackSequence: ...
-    
+
     // messageType should be NOOP_RESPONSE
     messageType: NOOP_RESPONSE
   }
@@ -348,13 +387,13 @@ command: {
 
 			// Required bytes
 	      	// Versions are set on objects to support optimistic locking.
-      		// For operations that modify data, if the dbVersion sent in the 
+      		// For operations that modify data, if the dbVersion sent in the
       		// request message does not match the version stored in the db, the
       		// request will fail.
 	      	dbVersion: "..."
 
 			// Required bytes
-      		// Specifies what the next version of the data will be if this 
+      		// Specifies what the next version of the data will be if this
       		// operation is successful.
 	      	newVersion: "..."
 
@@ -365,9 +404,9 @@ command: {
 
 			// Optional bytes
 	      	// The integrity value for the data. This value should be computed
-      		// by the client application by applying the hash algorithm 
-      		// specified below to the value (and only to the value). 
-      		// The algorithm used should be specified in the algorithm field. 
+      		// by the client application by applying the hash algorithm
+      		// specified below to the value (and only to the value).
+      		// The algorithm used should be specified in the algorithm field.
       		// The Kinetic Device will not do any processing on this value.
       		tag: "..."
 
@@ -376,15 +415,15 @@ command: {
       		algorithm: ...
 
 		// Optional Synchronization enum value, defaults to WRITETHROUGH
-      		// Allows client to specify if the data must be written to disk 
+      		// Allows client to specify if the data must be written to disk
       		// immediately, or can be written in the future.
       		//
       		// WRITETHROUGH:  This request is made persistent before returning.
       		//                This does not effect any other pending operations.
       		// WRITEBACK:     They can be made persistent when the drive chooses,
       		//        	  or when a subsequent FLUSH is give to the drive.
-      		// FLUSH: 	  All pending information that has not been written is 
-      		//		  pushed to the disk and the command that specifies 
+      		// FLUSH: 	  All pending information that has not been written is
+      		//		  pushed to the disk and the command that specifies
       		// 		  FLUSH is written last and then returned. All WRITEBACK writes
       		//		  that have received ending status will be guaranteed to be
       		//		  written before the FLUSH operation is returned completed.
@@ -500,7 +539,7 @@ command {
   // See top level cross cutting concerns for header details
   header {
     ackSequence: ...
-    
+
     // messageType should be DELETE_RESPONSE
     messageType: DELETE_RESPONSE
   }
@@ -596,13 +635,13 @@ keyValue {
       // Optional bool, defaults to false.
       // If true, only metadata (not the full value) will be returned
       // If false, metadata and value will be returned
-	  metadataOnly: ...    
+	  metadataOnly: ...
 }
 ```
 
 
 ### GET
-The `GET` operation is used to retrieve the value and metadata for a given key. 
+The `GET` operation is used to retrieve the value and metadata for a given key.
 
 **Request Message**
 
@@ -614,7 +653,7 @@ command {
     identity: ...
     connectionID: ...
     sequence: ...
-    
+
     // The mesageType should be GET
     messageType: GET
   }
@@ -633,7 +672,7 @@ hmac: "..."
 
 A successful response will return the value in the top level Kinetic PDU, and will have a `SUCCESS` status:
 
- ```   
+ ```
 command {
   header {
   	// See above
@@ -737,8 +776,8 @@ command {
   }
   body {
     keyValue {
-      // A key is required. Note that this is different from GET in that you 
-      // will not get the value for this key, but the value for the subsequent 
+      // A key is required. Note that this is different from GET in that you
+      // will not get the value for this key, but the value for the subsequent
       // key in the ordering.
       key: "..."
     }
@@ -763,7 +802,7 @@ command {
       // This is the key for the value that is being returned
       // This will be different from the key passed in the request
       key: "..."
-      
+
       // These fields are documented above
       dbVersion: "..."
       tag: "..."
@@ -771,7 +810,7 @@ command {
     }
   }
   status {
-	// If the operation does not succeed, a different code will be specified. 
+	// If the operation does not succeed, a different code will be specified.
 	// See below.
     code: SUCCESS
   }
@@ -783,10 +822,10 @@ hmac: "..."
 Error Cases:
 
 * `code = NOT_FOUND`
-	* There is no key in the store that is sorted after the given key. 
+	* There is no key in the store that is sorted after the given key.
 	* This can occur if the given key is the last key in the store, of if the key given is not included in the store but would be sorted after the last key.
 * `code = NOT_AUTHORIZED` The identity does not have read permission on the key that would be returned.
-	
+
 Edge Cases:
 
  * If a `key` is provided which is not found in the store, the service will find the first key which would be sorted after the given key. For example, if the store has keys `key0` and `key2` and the client sends a request for `GETNEXT` of `key1`, the device will return the value for `key2`.
@@ -810,10 +849,10 @@ command {
   }
   body {
     keyValue {
-      // A key is required. Note that this is different from GET in that you 
+      // A key is required. Note that this is different from GET in that you
       // will not get the value for this key, but the value for the subsequent
       // key in the ordering.
-      
+
       key: "..."
     }
   }
@@ -837,7 +876,7 @@ command {
       // This is the key for the value that is being returned
       // This will be different from the key passed in the request
       key: "..."
-      
+
       // These fields are documented above
       dbVersion: "..."
       tag: "..."
@@ -845,7 +884,7 @@ command {
     }
   }
   status {
-	// If the operation does not succeed, a different code will be specified. 
+	// If the operation does not succeed, a different code will be specified.
 	// See below.
     code: SUCCESS
   }
@@ -857,11 +896,11 @@ hmac: "..."
 Error Cases:
 
 * `code = NOT_FOUND`
-	* There is no key in the store that is sorted brefore the given key. 
+	* There is no key in the store that is sorted brefore the given key.
 	* This can occur if the given key is the first key in the store, of if the key given is not included in the store but would be sorted before the first key.
 * `code = NOT_AUTHORIZED`:
 	* If the identity does not have read permission on the key that would be returned.
-	
+
 Edge Cases:
 
  * If a `key` is provided which is not found in the store, the service will find the first key which would be sorted before the given key. For example, if the store has keys `key0` and `key2` and the client sends a request for `GETPREVIOUS` of `key1`, the device will return the value for `key0`.
@@ -884,7 +923,7 @@ command {
     identity: ...
     connectionID: ...
     sequence: ...
-    
+
     // messageType should be GETKEYRANGE
     messageType: GETKEYRANGE
   }
@@ -893,24 +932,24 @@ command {
     range {
       // Required bytes, the beginning of the requested range
       startKey: "..."
-      
+
       // Optional bool, defaults to false
-      // True indicates that the start key should be included in the returned 
+      // True indicates that the start key should be included in the returned
       // range
       startKeyInclusive: ...
-      
+
       // Required bytes, the end of the requested range
       endKey: "..."
 
       // Optional bool, defaults to false
-      // True indicates that the end key should be included in the returned 
+      // True indicates that the end key should be included in the returned
       // range
       endKeyInclusive: ...
-      
+
       // Required int32, must be greater than 0
       // The maximum number of keys returned, in sorted order
       maxReturned: ...
-      
+
       // Optional bool, defaults to false
       // If true, the key range will be returned in reverse order, starting at
       // endKey and moving back to startKey.  For instance
@@ -933,8 +972,8 @@ command {
     messageType: GETKEYRANGE_RESPONSE
   }
   body {
-  	// The range message is populated with up to maxReturned keys. 
-  	// If no keys are found in the range then the range message will be omitted 
+  	// The range message is populated with up to maxReturned keys.
+  	// If no keys are found in the range then the range message will be omitted
   	// and the status code will be SUCCESS
     range {
       key: "..."
@@ -974,25 +1013,25 @@ The `SETUP` operation can be used to set the device's `clusterVersion` and `pin`
 
 **Request Message**
 
-``` 
+```
 command {
   header {
     // Important: this should be the current cluster version. This operation is
-    // intended to change the clusterVersion, but the current clusterVersion 
+    // intended to change the clusterVersion, but the current clusterVersion
     // must be specified here.
     clusterVersion: ...
-    
+
 	// See top level cross cutting concerns for header details
     identity: ...
     connectionID: ...
     sequence: ...
-    
+
 	// The messageType should be SETUP
     messageType: SETUP
   }
   body {
     setup {
-      // Required int64, needed to update the cluster version 
+      // Required int64, needed to update the cluster version
       // (otherwise request will be treated as a different Setup operation)
       // This is the clusterVersion being set on the device.
       newClusterVersion: 1
@@ -1038,7 +1077,7 @@ command {
   }
   body {
     setup {
-      // Required bool, defaults to false if omitted. 
+      // Required bool, defaults to false if omitted.
       // Must be true for this request to be treated as an ISE.
       instantSecureErase: true
     }
@@ -1082,7 +1121,7 @@ command {
   }
   body {
     setup {
-      // Required bool, must be present and true to indicate that this is 
+      // Required bool, must be present and true to indicate that this is
       // a firmware download operation.
       // Indicates that the value (in the Kinetic PDU) will contain the firmware
       firmwareDownload: true
@@ -1133,14 +1172,14 @@ command {
     identity: ...
     connectionID: ...
     sequence: ...
-    
+
     // messageType should be SECURITY
     messageType: SECURITY
   }
   body {
-    // The security message must be present and contain at least one acl 
+    // The security message must be present and contain at least one acl
     // message. Multiple are allowed but only one can be specified per identity.
-    // Note that security message overwrites the stored ACL list entirely, 
+    // Note that security message overwrites the stored ACL list entirely,
     // no updating is supported.
     security {
       acl {
@@ -1148,10 +1187,10 @@ command {
         identity: 1
         // Required bytes, the identity's HMAC key, a shared secret
         key: "...."
-        // Required HMACAlgorithm, the algorithm used to compute the HMAC for 
+        // Required HMACAlgorithm, the algorithm used to compute the HMAC for
         // this identity
         hmacAlgorithm: ...
-        
+
         // The scope message has at least one permission, in this example there
         // are many
         scope {
@@ -1165,7 +1204,7 @@ command {
           permission: SECURITY
         }
       }
-      
+
       // This ACL shows that multiple scopes can be set for a identity in one
       // ACL message
       acl {
@@ -1177,9 +1216,9 @@ command {
         scope {
           permission: READ
         }
-        
+
         // This scope gives identity 2 the ability to write keys if and only if
-        // "test" is a substring of key starting at offset 3. For example, with 
+        // "test" is a substring of key starting at offset 3. For example, with
         // this scope identity 2 could PUT keys: "xyztest1", "001test2", etc
         // but could not put keys: "somethingElse", "test123", "1234test"
         scope {
@@ -1188,7 +1227,7 @@ command {
           permission: WRITE
         }
       }
-      
+
       // More ACLs for additional identities may be specified in the
       // same security message...
       acl {
@@ -1220,7 +1259,7 @@ hmac: "..."
 command {
   header {
     ackSequence: ...
-    
+
     // messageType should be SECURITY_RESPONSE
     messageType: SECURITY_RESPONSE
   }
@@ -1271,7 +1310,7 @@ command {
   }
   body {
     // The body should contain a getLog message, which must have
-    // at least one value for type. Multiple are allowed. 
+    // at least one value for type. Multiple are allowed.
     // Here all types are requested.
     getLog {
       type: CAPACITIES
@@ -1305,23 +1344,23 @@ command {
       type: TEMPERATURES
       type: UTILIZATIONS
       type: LIMITS
-      
+
       // Many utilization messages may be returned
       utilization {
-      	// Required string, the name of the rescource being reported       
+      	// Required string, the name of the rescource being reported
       	// For example: HDA, ENO, CPU...
         name: "..."
         // Required float, the value for this resource's utilization.
         // value will be between 0.00 and 1.00.
         value: 0.2
       }
-      
+
       utilization {
         name: "...""
         value: ...
       }
       ...
-      
+
       // Many temperature messages may be returned
       temperature {
       	// Required string, the name of the resource being reported
@@ -1333,13 +1372,13 @@ command {
         minimum: 5.0
         // Required float, the current temperature in degrees celcius
         maximum: 100.0
-		// Required float, the current temperature in degrees celcius        
+		// Required float, the current temperature in degrees celcius
         target: 25.0
       }
-	
-	  // Only one configuration message will be included      
+
+	  // Only one configuration message will be included
       configuration {
-        // string, the vendor of the Kinetic Device. 
+        // string, the vendor of the Kinetic Device.
         vendor: "..."
 
         // string, the model of the Kinetic Device
@@ -1373,7 +1412,7 @@ command {
         // string, a checksum of the source code
         sourceHash: "..."
       }
-      
+
       // There should be one statistics message per messageType (GET, PUT, etc)
       // The statistics messages aggregate statistics for each messageType.
       statistics {
@@ -1381,7 +1420,7 @@ command {
         messageType: PUT
         // Required sint64, how many times this messageType has been received
         count: ...
-        // Required sint64, the sum length of all the value portion of the 
+        // Required sint64, the sum length of all the value portion of the
         // Kinetic PDU messages sent since starting the Kinetic Device
         bytes: ...
       }
@@ -1391,7 +1430,7 @@ command {
         count: ...
         bytes: ...
       }
-      
+
       // Only one capacity message will be included
       capacity {
         // uint64
@@ -1399,10 +1438,10 @@ command {
       	// float
       	portionFull: ...
       }
-      
+
       // bytes representing recent Kinetic Device log messages
       messages: "..."
-      
+
       // limits that the device will enforce
       limits {
         maxKeySize = ...
@@ -1425,7 +1464,7 @@ command {
 
 
 ## Peer to Peer
-The `PEER2PEERPUSH` operation allows a client to instruct a Kinetic Device to copy a set of keys (and associated value and metadata) to another Kinetic Device. Peer To Peer operations can be nested, so a client could tell device A to copy certain keys to device B, and then have device B copy a set of keys to device C, and so on. 
+The `PEER2PEERPUSH` operation allows a client to instruct a Kinetic Device to copy a set of keys (and associated value and metadata) to another Kinetic Device. Peer To Peer operations can be nested, so a client could tell device A to copy certain keys to device B, and then have device B copy a set of keys to device C, and so on.
 
 
 **Request Message**
@@ -1446,7 +1485,7 @@ command {
         hostname: "..."
         // Required int32, the port on which the peer is running the Kinetic service
         port: ...
-        // Optional boolean, defaults to false. 
+        // Optional boolean, defaults to false.
         // Currently SSL is not supported so this must be false.
         tls: ...
       }
@@ -1454,16 +1493,16 @@ command {
       	// Required bytes, the key to copy from the source peer.
         key: ""
 
-		// Optional bytes, the 
+		// Optional bytes, the
 		version: "..."
-		
+
 		// Optional bool, defaults to false
 		// If true, force write ignoring version
 		force: ...
-		
+
   		// Optional bytes, the key to use in the destination peer.
 		newKey: "..."
-		
+
 		// This is a nested Peer To Peer Push operation. The recursive structure
 		// allows arbitrarily deep (up to the message size cap) nesting of
 		// p2p operations.
@@ -1521,10 +1560,10 @@ command {
           operation {
             key: "..."
 			status {
-				// Status messages can be nested. This is what it would be 
+				// Status messages can be nested. This is what it would be
 				// returned if an operation failed because the key was not found
          	 	code: NOT_FOUND
-	     	}           
+	     	}
           }
           operation: {
           	key: "...",


### PR DESCRIPTION
Added table of contents to README.md generated with [DocToc](http://doctoc.herokuapp.com/)

I pointed doctoc at the README.md on the tip of master via the following URL, and pressed the button:
https://github.com/protobuf-c/protobuf-c/blob/master/README.md

I then just paster the full generated TOC markdown blob, added a TAC section header, and moved/tweaked the DocToc shout-out the end of the blob. Feel free to remove the shoutout if desired.

Original shout-out:

```markdown
**Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
```

Tweaked shout-out:

```markdown
_Table of Contents generated with [DocToc](http://doctoc.herokuapp.com/)_
```

Since the TOC is now in its own 'section', generating an updated TOC will have an entry for the TOC section which can just be removed manually.