### PR TITLE
Autotools build infrastructure for kinetic-protocol libraries

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,51 @@
+ACLOCAL_AMFLAGS = -I m4
+
+EXTRADIST = LICENSES README.md README.autotools
+
+lib_LTLIBRARIES =
+if ENABLE_CPP
+# kientic protocol library for cpp clients
+lib_LTLIBRARIES += libkinetic.pb.la
+libkinetic_pb_la_SOURCES = cpp/kinetic.pb.cc cpp/kinetic.pb.h
+libkinetic_pb_la_includedir = $(includedir)/kinetic
+libkinetic_pb_la_include_HEADERS = cpp/kinetic.pb.h
+libkinetic_pb_la_CFLAGS = -I$(top_srcdir) -Wall -Werror -fPIC
+libkinetic_pb_la_LDFLAGS = -Wl -release @PACKAGE_VERSION@ @LDFLAGS@
+
+cpp/kinetic.pb.cc cpp/kinetic.pb.h: $(top_srcdir)/kinetic.proto
+	mkdir -p cpp
+	@PROTOC@ --cpp_out=cpp --proto_path=$(top_srcdir) $(top_srcdir)/kinetic.proto
+endif
+
+if ENABLE_C
+# kientic protocol library for c clients
+lib_LTLIBRARIES += libkinetic.pb-c.la
+libkinetic_pb_c_la_SOURCES = c/kinetic.pb-c.c c/kinetic.pb-c.h
+libkinetic_pb_c_la_includedir = $(includedir)/kinetic
+libkinetic_pb_c_la_include_HEADERS = c/kinetic.pb-c.h
+libkinetic_pb_c_la_CFLAGS = -I$(top_srcdir) -Wall -Werror -fPIC
+libkinetic_pb_c_la_LDFLAGS = -Wl -release @PACKAGE_VERSION@ @LDFLAGS@
+
+c/kinetic.pb-c.c c/kinetic.pb-c.h: $(top_srcdir)/kinetic.proto
+	mkdir -p c
+	@PROTOCC@ --c_out=c --proto_path=$(top_srcdir) $(top_srcdir)/kinetic.proto
+endif
+
+if ENABLE_PYTHON
+# kinetic protocol  library for python clients
+kinetic_pb2dir = @pyexecdir@/kinetic
+kinetic_pb2_PYTHON = py/kinetic_pb2.py py/__init__.py
+
+py/kinetic_pb2.py: $(top_srcdir)/kinetic.proto
+	mkdir -p py
+	@PROTOC@ --python_out=py --proto_path=$(top_srcdir) $(top_srcdir)/kinetic.proto
+py/__init__.py: py/kinetic_pb2.py
+	touch py/__init__.py
+endif
+
+clean-local:
+	rm -f c/kinetic.pb-c.* cpp/kinetic.pb.* py/kinetic_pb2.*
+distclean-local:
+	rm -rf c cpp py
+	rm -f aclocal.m4 ar-lib compile config.guess config.sub config.h.in configure depcomp install-sh ltmain.sh Makefile.in missing py-compile
+	rm -rf m4 autom4te.cache

--- a/README.build
+++ b/README.build
@@ -1,0 +1,57 @@
+Introduction
+============
+This repository provides the code for building the kinetic-protocol library for
+these languages:
+
+* c
+* cpp
+* python
+
+Support for more languages can be added as needed in the future.
+
+Dependencies
+============
+The following versions of dependent packages are known to work well while
+building current kinetic clients from the github kinetic repository. These
+versions are recommended, while other versions may also work.
+
+* autoconf-2.69
+* protobuf-c-1.0.1
+* protobuf-compiler-2.6.0
+* gcc toolchain
+
+Build Instructions
+==================
+To build kinetic-protocol libraries, install the above mentioned dependencies,
+and run the commands mentioned in the following steps.
+
+1. To generate configure script from autotools, run autogen.sh script from top
+source directory:
+	./autogen.sh
+
+2. Run configure script from the top source directory:
+	./configure
+
+   By-default, the configure script enables kinetic-protocol library builds
+for c, cpp and disables the library build for python. It is possible to
+override this default behavior by "enable-feature" argument to configure
+script.
+
+   For example, to enable build for python,
+        ./configure --enable-python=yes
+
+Similarly, it is possible to disable c and cpp library builds with parameters
+"enable-c=no" and "enable-cpp=no"
+
+3. Build the kientic-protocol libraries from the build directory:
+	make
+
+4. Install the kientic-protocol libraries and headers:
+	make install
+
+5. Uninstall the kinetic-protocol libraries and headers:
+	make uninstall
+
+6. Clean the directory for another clean build:
+	make clean
+	make distclean

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+libtoolize
+aclocal -I m4
+autoheader
+autoconf
+automake --add-missing
+
+# If there are any options, assume the user wants to run configure.
+# To run configure w/o any options, use ./autogen.sh --configure
+if [ $# -gt 0 ] ; then
+        case "$1" in
+        --conf*)
+                shift 1
+                ;;
+        esac
+    exec ./configure  "$@"
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,109 @@
+#                                               -*- Autoconf -*-
+# Process this file with autoconf to produce a configure script.
+
+AC_PREREQ([2.69])
+AC_INIT([kinetic-protocol],
+    m4_esyscmd_s(echo $(grep ' *optional string protocolVersion = 1 .default =' kinetic.proto | sed 's/.* = \"//;s/\".*//')),
+    [info@openkinetic.org])
+
+AC_CONFIG_SRCDIR([kinetic.proto])
+AC_CONFIG_HEADERS([config.h])
+AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
+AC_CONFIG_MACRO_DIR([m4])
+
+# Checks for programs.
+AC_PROG_CC
+AM_PROG_CC_C_O
+AC_PROG_CXX
+if x$ac_cv_prog_ac_ct_CXX = x ; then
+	AC_MSG_ERROR(no C++ compiler found)
+fi
+m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
+AC_PROG_INSTALL
+AM_PROG_LIBTOOL
+
+AC_ARG_ENABLE(python,
+        [AS_HELP_STRING([--enable-python[[=yes/no]]],[enable building for python [default=no]])],
+        enable_python=$enableval, enable_python=no)
+if test "$enable_python" = "yes"; then
+        AM_PATH_PYTHON
+fi
+AM_CONDITIONAL([ENABLE_PYTHON], [test x$enable_python = xyes])
+
+AC_ARG_ENABLE(cpp,
+        [AS_HELP_STRING([--enable-cpp[[=yes/no]]],[enable building library for C++ [default=yes]])],
+        enable_cpp=$enableval, enable_cpp=yes)
+AM_CONDITIONAL([ENABLE_CPP], [test x$enable_cpp = xyes])
+
+AC_ARG_ENABLE(c,
+        [AS_HELP_STRING([--enable-c[[=yes/no]]],[enable building library for C [default=yes]])],
+        enable_c=$enableval, enable_c=yes)
+AM_CONDITIONAL([ENABLE_C], [test x$enable_c = xyes])
+if test "$enable_c" = "yes" || test "$enable_cpp" = "yes" || test "$enable_python" = "yes"; then
+        AC_PATH_PROG(PROTOC, protoc, not-found)
+        AS_IF([test "$PROTOC" = "not-found"], [AC_MSG_ERROR(cannot find protoc)])
+        PROTOC_VERSION=`$PROTOC --version | awk '{ print $2}'`
+        AC_MSG_CHECKING([is protoc version >= 2.5.0])
+        AS_VERSION_COMPARE(${PROTOC_VERSION}, 2.5.0, [RESULT=-1], [RESULT=0], [RESULT=1])
+        AS_IF([test "${RESULT}" != "-1"], AC_MSG_RESULT([found protoc $PROTOC_VERSION]),
+                AC_MSG_ERROR([found protoc v$PROTOC_VERSION needed v2.5.0 or higher]))
+fi
+if test "$enable_c" = "yes"; then
+        AC_PATH_PROG(PROTOCC, protoc-c, not-found)
+        AS_IF([test "$PROTOCC" = "not-found"], [AC_MSG_ERROR(cannot find protoc-c)])
+        PROTOBUFC_VERSION=`$PROTOCC --version | head -n1 | awk '{ print $2}'`
+        AC_MSG_CHECKING([is protobuf-c version >= 1.0.1])
+        AS_VERSION_COMPARE(${PROTOBUFC_VERSION}, 1.0.1, [RESULT=-1], [RESULT=0], [RESULT=1])
+        AS_IF([test "${RESULT}" != "-1"], AC_MSG_RESULT([found protoc-c $PROTOBUFC_VERSION]),
+                AC_MSG_ERROR([found protobuf-c v$PROTOBUFC_VERSION needed v1.0.1 or higher]))
+
+        AC_CHECK_HEADER([protobuf-c/protobuf-c.h], [],
+		[AC_CHECK_HEADER([google/protobuf-c/protobuf-c.h],
+			[CPPFLAGS="${CPPFLAGS} -Igoogle"],
+			[AC_MSG_ERROR(cannot find protobuf-c headers)])])
+fi
+
+if test "$enable_cpp" = "yes"; then
+        AC_LANG_PUSH([C++])
+        AC_CHECK_HEADER([google/protobuf/stubs/common.h],[],
+                AC_MSG_ERROR(cannot find protobuf headers))
+        AC_LANG_POP
+fi
+
+AC_ARG_ENABLE(java,
+        [AS_HELP_STRING([--enable-java[[=yes/no]]],[enable building library for java [default=no]])],
+        enable_java=$enableval, enable_java=no)
+if test "$enable_java" = "yes"; then
+        AC_MSG_ERROR(building java library - feature not supported yet)
+fi
+AM_CONDITIONAL([ENABLE_JAVA], [test x$enable_java = xyes])
+
+AC_CONFIG_FILES([Makefile])
+
+AC_OUTPUT
+
+AC_MSG_RESULT([
+	$PACKAGE-$VERSION
+	CC:		${CC}
+	CPP:		${CPP}
+	CFLAGS:		${CFLAGS}
+	CPPFLAGS:	${CPPFLAGS}
+	CXX:		${CXX}
+	CXXCPP:		${CXXCPP}
+	CXXFLAGS:	${CXXFLAGS}
+	LDFLAGS:	${LDFLAGS}
+	LIBS:		${LIBS}
+
+	prefix:		${prefix}
+	exec_prefix:	${exec_prefix}
+	libdir:		${libdir}
+	includedir:	${includedir}
+	bindir:		${bindir}
+])
+if test "$enable_python" = "yes"; then
+AC_MSG_RESULT([
+	PYTHON:		${PYTHON}
+	pyexecdir:	${pyexecdir}
+	pythondir	${pythondir}
+])
+fi


### PR DESCRIPTION
Provide the build support to build kinetic-protocol specific libraries for
utilization in C, C++ & python applications.

The autotools also enables the build setup in cross and various
architectures.

The build supports building shared libraries for C, C++ and python.
The individual libraries can be enabled or disabled through the
configure options.

The Autotools build procedure is documented in the README.build
file. It provides information on build steps from scratch for
a native build.

Signed-off-by: Kinjal Patel <kinjal.patel@taec.toshiba.com>
Signed-off-by: Nitin A Kamble <Nitin.Kamble@taec.toshiba.com>