### PR TITLE
Fix typo in kinetic.proto

### DIFF
--- a/kinetic.proto
+++ b/kinetic.proto
@@ -28,7 +28,7 @@ message Local {
 // THe message is an authorization and command bytes.
 message Message {
 
-// 1-3 are reserved, do not u
+// 1-3 are reserved, do not use
 
 // Every message must be one of the following types.
 	optional AuthType authType = 4;


### PR DESCRIPTION
Replace "u" with "use" in kinetic.proto.